### PR TITLE
BUGFIX BlogPostDataExtension::getFirstContent() not casting

### DIFF
--- a/src/ORM/BlogPostDataExtension.php
+++ b/src/ORM/BlogPostDataExtension.php
@@ -24,6 +24,13 @@ class BlogPostDataExtension extends DataExtension
     ];
 
     /**
+     * @var array
+     */
+    private static $casting = [
+        'FirstContent' => 'HTMLText',
+    ];
+
+    /**
      * @param FieldList $fields
      */
     public function updateCMSFields(FieldList $fields)


### PR DESCRIPTION
resolves #76

Another ticket will be opened to determine if an adjustment should be made to inject the collective content of the blocks into the content field for a "minutes to read" fix and for a safe `$Content.FirstParagraph` fallback