### PR TITLE
REFACTOR remove geocoder requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "axllent/silverstripe-email-obfuscator": "^2",
         "axllent/silverstripe-scaled-uploads": "^2.1",
         "dnadesign/silverstripe-elemental": "^5",
-        "dynamic/silverstripe-geocoder": "^3",
         "dynamic/silverstripe-site-tools": "^3",
         "jonom/silverstripe-betternavigator": "^6",
         "jonom/silverstripe-text-target-length": "^2",


### PR DESCRIPTION
no longer necessary via `innoweb/silverstripe-social-metadata`