### PR TITLE
fix: SS 5.4 compatibility for SocialLink and TemplateDataExtension test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "axllent/silverstripe-email-obfuscator": "^2",
         "axllent/silverstripe-scaled-uploads": "^2.1",
         "dnadesign/silverstripe-elemental": "^5",
-        "dynamic/silverstripe-site-tools": "^4",
+        "dynamic/silverstripe-site-tools": "^5.1",
         "jonom/silverstripe-betternavigator": "^6",
         "jonom/silverstripe-text-target-length": "^2",
         "silverstripe/linkfield": "^4.0",

--- a/tests/Extension/TemplateDataExtensionTest.php
+++ b/tests/Extension/TemplateDataExtensionTest.php
@@ -3,9 +3,10 @@
 namespace Dynamic\Base\Test\Extension;
 
 use Dynamic\Base\Extension\TemplateDataExtension;
-use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Tab;
+use SilverStripe\Forms\TabSet;
 use SilverStripe\SiteConfig\SiteConfig;
 
 class TemplateDataExtensionTest extends SapphireTest
@@ -25,13 +26,21 @@ class TemplateDataExtensionTest extends SapphireTest
     ];
 
     /**
-     *
+     * Tests that TemplateDataExtension::updateCMSFields adds branding fields.
      */
-    public function testGetCMSFields()
+    public function testUpdateCMSFieldsAddsBrandingFields()
     {
-        $object = Injector::inst()->create(SiteConfig::class);
-        $fields = $object->getCMSFields();
-        $this->assertInstanceOf(FieldList::class, $fields);
+        // Test updateCMSFields directly to avoid interference from
+        // other extensions (e.g. essentials-tools) that may remove fields
+        $object = SiteConfig::create();
+        $fields = FieldList::create(TabSet::create('Root', Tab::create('Main')));
+        $extension = $object->getExtensionInstance(TemplateDataExtension::class);
+        $this->assertNotNull($extension);
+        $extension->setOwner($object);
+        $extension->updateCMSFields($fields);
+
+        $this->assertNotNull($fields->dataFieldByName('TitleLogo'));
         $this->assertNotNull($fields->dataFieldByName('Logo'));
+        $this->assertNotNull($fields->dataFieldByName('LogoRetina'));
     }
 }


### PR DESCRIPTION
## Summary

Fixes test stability and updates dependency constraints for Silverstripe 5.4 compatibility.

## Changes

### Test Stabilization (`TemplateDataExtensionTest.php`)
- Renamed `testGetCMSFields` → `testUpdateCMSFieldsAddsBrandingFields` to reflect what's actually tested
- Uses `getExtensionInstance()` for proper SilverStripe extension wiring
- Tests `updateCMSFields()` directly with a controlled `FieldList` to avoid interference from downstream extensions (e.g. `essentials-tools`) that remove branding fields
- Adds assertions for `TitleLogo`, `Logo`, and `LogoRetina` fields

### Dependency Update (`composer.json`)
- Bumped `dynamic/silverstripe-site-tools` from `^4` to `^5.1`
- **Reason**: `site-tools 5.1.0` (dynamic/silverstripe-site-tools#33) widens `silverstripe/linkfield` to `^4.0 || ^5.0`, resolving CI dependency conflicts when the test matrix installs against newer installer versions

## Closes #164