### PR TITLE
fix: remove parent::onBeforeWrite() from SeoExtension

### DIFF
--- a/src/Extension/SeoExtension.php
+++ b/src/Extension/SeoExtension.php
@@ -124,9 +124,8 @@ class SeoExtension extends Extension
     /**
      *
      */
-    public function onBeforeWrite()
+    public function onBeforeWrite(): void
     {
-        parent::onBeforeWrite();
 
         // set SearchContent to output of blocks for search
         if ($this->owner->hasMethod('getElementsForSearch')) {


### PR DESCRIPTION
SS6 Extensions no longer support parent lifecycle calls. Fixes fatal error during dev/build.