### PR TITLE
fix(tests): test TemplateDataExtension in isolation

### DIFF
--- a/tests/Extension/TemplateDataExtensionTest.php
+++ b/tests/Extension/TemplateDataExtensionTest.php
@@ -6,6 +6,8 @@ use Dynamic\Base\Extension\TemplateDataExtension;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Tab;
+use SilverStripe\Forms\TabSet;
 use SilverStripe\SiteConfig\SiteConfig;
 
 class TemplateDataExtensionTest extends SapphireTest
@@ -25,13 +27,22 @@ class TemplateDataExtensionTest extends SapphireTest
     ];
 
     /**
-     *
+     * Test the extension method in isolation, bypassing other registered
+     * extensions (e.g. SiteConfigExtension from essentials-tools removes
+     * Logo/TitleLogo in non-EssentialsConfig contexts, which would cause
+     * this assertion to fail in recipe CI where that extension is loaded).
      */
-    public function testGetCMSFields()
+    public function testUpdateCMSFields()
     {
-        $object = Injector::inst()->create(SiteConfig::class);
-        $fields = $object->getCMSFields();
+        $siteConfig = Injector::inst()->create(SiteConfig::class);
+        $fields = FieldList::create(TabSet::create('Root', Tab::create('Main')));
+
+        /** @var TemplateDataExtension $ext */
+        $ext = $siteConfig->getExtensionInstance(TemplateDataExtension::class);
+        $ext->updateCMSFields($fields);
+
         $this->assertInstanceOf(FieldList::class, $fields);
         $this->assertNotNull($fields->dataFieldByName('Logo'));
+        $this->assertNotNull($fields->dataFieldByName('LogoRetina'));
     }
 }


### PR DESCRIPTION
## Summary

- Rewrites `TemplateDataExtensionTest::testGetCMSFields` to call `updateCMSFields()` directly on the extension instance, bypassing the full `getCMSFields()` extension chain.

## Root cause

`SiteConfigExtension` from `silverstripe-essentials-tools` explicitly removes `Logo`, `LogoRetina`, and `TitleLogo` from `SiteConfig::getCMSFields()` (those fields moved to `EssentialsConfig`). When `recipe-silverstripe-essentials-website` runs its full test suite, essentials-tools is in vendor and its YAML registers `SiteConfigExtension` globally — it fires after `TemplateDataExtension` and strips the Logo field, causing `assertNotNull($fields->dataFieldByName('Logo'))` to fail.

The test in base-site's own CI passes because essentials-tools is not a dependency, so `SiteConfigExtension` is never registered.

## Fix

Call `$siteConfig->getExtensionInstance(TemplateDataExtension::class)->updateCMSFields($fields)` directly on a fresh `FieldList`. This tests only `TemplateDataExtension`'s behavior in isolation, independent of whatever other extensions happen to be loaded.

Closes #1