### PR TITLE
chore(#176): remove stale branch-alias pointing at legacy master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,10 +45,5 @@
             "silverstripe/vendor-plugin": true
         },
         "process-timeout": 600
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "8.0.x-dev"
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Removes \`extra.branch-alias\` (\`dev-master: 8.0.x-dev\`) — a leftover from the integer-branch migration. The \`8\` branch already resolves to \`8.x-dev\` on its own; the alias only made the stale legacy \`master\` branch a valid \`^8.0@dev\` candidate.

Closes #176

Found while auditing suite-wide composer.json VCS/alias plumbing (see essentials-ss6 audit, unrelated to the dnadesign/silverstripe-embed 2.0.0 release that prompted the check).

## Test plan
- [x] Resulting composer.json is valid JSON
- [ ] \`composer show dynamic/silverstripe-base-site\` in a consumer still resolves to \`8.x-dev\`, not \`8.0.x-dev\`/legacy \`master\`